### PR TITLE
Added the possibility to use EnvVars for the TestRunner- and ProjectFile-paths

### DIFF
--- a/src/main/java/com/smartbear/ready/jenkins/ProcessRunner.java
+++ b/src/main/java/com/smartbear/ready/jenkins/ProcessRunner.java
@@ -160,7 +160,7 @@ class ProcessRunner {
 
         isReportCreated = false;
         isPrintableReportCreated = false;
-        Launcher.ProcStarter processStarter = launcher.launch().cmds(processParameterList).envs(run.getEnvironment(listener)).readStdout().quiet(true);
+        Launcher.ProcStarter processStarter = launcher.launch().cmds(processParameterList).envs(envVars).readStdout().quiet(true);
         out.println("Starting ReadyAPI functional test.");
 
         final Proc process = processStarter.start();

--- a/src/main/java/com/smartbear/ready/jenkins/ProcessRunner.java
+++ b/src/main/java/com/smartbear/ready/jenkins/ProcessRunner.java
@@ -1,5 +1,6 @@
 package com.smartbear.ready.jenkins;
 
+import hudson.EnvVars;
 import hudson.FilePath;
 import hudson.Launcher;
 import hudson.Proc;
@@ -61,7 +62,8 @@ class ProcessRunner {
         List<String> processParameterList = new ArrayList<>();
         channel = launcher.getChannel();
         setSlaveFileSeparator(launcher);
-        String testrunnerFilePath = buildTestRunnerPath(params.getPathToTestrunner(), launcher);
+        EnvVars envVars = run.getEnvironment(listener);
+        String testrunnerFilePath = buildTestRunnerPath(envVars.expand(params.getPathToTestrunner()), launcher);
         FilePath testrunnerFile = new FilePath(channel, testrunnerFilePath);
         if (StringUtils.isNotBlank(testrunnerFilePath) && testrunnerFile.exists() && testrunnerFile.length() != 0) {
             try {
@@ -124,7 +126,7 @@ class ProcessRunner {
             processParameterList.addAll(Arrays.asList("-E", params.getEnvironment()));
         }
 
-        String projectFilePath = params.getPathToProjectFile();
+        String projectFilePath = envVars.expand(params.getPathToProjectFile());
         FilePath projectFile = new FilePath(channel, projectFilePath);
         if (StringUtils.isNotBlank(projectFilePath) && projectFile.exists() && (projectFile.isDirectory() || projectFile.length() != 0)) {
             try {


### PR DESCRIPTION
Because we are installing the TestRunner automatically on Jenkins (Custom Tools) and we have several different configurations of workers (AIX, Linux, Windows & Docker), not all of our users know the location of the TestRunner. Because Custom Tools adds the EnvVar '&lt;TOOL&gt;_HOME', this change adds the possibility to use this EnvVar in the path to the TestRunner.
Did the same for the ProjectFile-path, because our customers normally have their Test-Projects in the workspace ($WORKSPACE) and these can be different across our configurations as well.
So, with this change, you can have a single configuration for several (if not all) different configurations.