### PR TITLE
Fallback to checking the workspace for ProjectFile if it wasn't found

### DIFF
--- a/src/main/java/com/smartbear/ready/jenkins/ProcessRunner.java
+++ b/src/main/java/com/smartbear/ready/jenkins/ProcessRunner.java
@@ -124,9 +124,10 @@ class ProcessRunner {
             processParameterList.addAll(Arrays.asList("-E", params.getEnvironment()));
         }
 
-        String projectFilePath = params.getPathToProjectFile();
-        FilePath projectFile = new FilePath(channel, projectFilePath);
-        if (StringUtils.isNotBlank(projectFilePath) && projectFile.exists() && (projectFile.isDirectory() || projectFile.length() != 0)) {
+        String projectFilePath;
+        if ((projectFilePath = testProjectFilePath(params.getPathToProjectFile())) != null ||
+                (projectFilePath = testProjectFilePath(params.getWorkspace() + slaveFileSeparator + params.getPathToProjectFile())) != null) {
+            FilePath projectFile = new FilePath(channel, projectFilePath);
             try {
                 checkIfSoapUIProProject(projectFile);
             } catch (Exception e) {
@@ -139,7 +140,7 @@ class ProcessRunner {
             }
             processParameterList.add(projectFilePath);
         } else {
-            out.println("Failed to load the project file [" + projectFilePath + "]");
+            out.println("Failed to load the project file [" + params.getPathToProjectFile() + "]");
             return null;
         }
 
@@ -190,6 +191,12 @@ class ProcessRunner {
 
         return process;
     }
+
+	private String testProjectFilePath(String projectFilePath)
+			throws IOException, InterruptedException {
+        FilePath projectFile = new FilePath(channel, projectFilePath);
+		return StringUtils.isNotBlank(projectFilePath) && projectFile.exists() && (projectFile.isDirectory() || projectFile.length() != 0) ? projectFilePath : null;
+	}
 
     public String getReportsFolderPath() {
         return reportsFolderPath;

--- a/src/main/resources/com/smartbear/ready/jenkins/JenkinsSoapUIProTestRunner/config.jelly
+++ b/src/main/resources/com/smartbear/ready/jenkins/JenkinsSoapUIProTestRunner/config.jelly
@@ -7,7 +7,7 @@
         <f:textbox/>
     </f:entry>
     <f:entry title="Path to ReadyAPI project" field="pathToProjectFile"
-             description="Specifies the fully-qualified name of the project file.">
+             description="Specifies the name of the project file, either fully-qualified or relative to the workspace.">
         <f:textbox/>
     </f:entry>
     <f:entry title="Test Suite" field="testSuite"


### PR DESCRIPTION
Because most our users have their test-projects checked into GIT or located on a file-server and copy them to the workspace, I figured it would be nice if they could just enter the path to their files relative to their workspaces.
This change will first check (like the original) if the file is found as a fully-qualified path. If this fails, it will prepend the workspace path and try again.