### PR TITLE
RIA-20223: Allow to pass SLM Access Key in Jenkins Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ### About
 
-A SmartBear plugin used to run ReadyAPI functional tests from Jenkins builds. 
+A SmartBear plugin used to run ReadyAPI functional tests from Jenkins builds.
 
 ### Requirements
 
@@ -15,8 +15,8 @@ Make sure you run Jenkins under the same user account you used to activate the R
 
 ### Configuration
 
-The build step has the following settings:  
-	
+The build step has the following settings:
+
 * **Path to testrunner** - Specifies the fully-qualified path to the runner file (*testrunner.bat* or *testrunner.sh*). By default, you can find it in the *<ReadyAPI installation>/bin* directory.
 * **Path to ReadyAPI project** -  Specifies the fully-qualified path to the ReadyAPI project you want to run.
 * **Test Suite** - Specifies the test suite to run. To run all the test suites of your project, leave the field blank.
@@ -24,6 +24,7 @@ The build step has the following settings:
 * **Test Suite Tags** and **Test Case Tags** - Specify which tags must contain the test suite or test case to be run. To create complex conditions, use the `||` (logical OR), `&&` (logical AND) and `!` (logical NOT) operators.
 * **Project Password** - Specifies the encryption password, if you encrypted the entire project or some of its custom properties.
 * **Environment** - Specifies the environment configuration for the test run.
+* **SLM Licence Access Key** - Specifies SLM Licence Access Key (Optional).
 
 ### Reports
 
@@ -50,11 +51,11 @@ You can find more information on how to use the plugin in [ReadyAPI documentatio
 
 #### Version 1.4 (April 10, 2020)
 
-* *Fixed*: A security vulnerability in project password storage. 
+* *Fixed*: A security vulnerability in project password storage.
 
 If you update to version 1.4, to ensure the security of your passwords, you need to do the following for all the jobs that use the plugin:
 
-1. Select a job and click **Configure**. 
+1. Select a job and click **Configure**.
 2. Save the configuration without making any changes by clicking **Save** or **Apply**.
 
 #### Version 1.3 (February 7, 2020)

--- a/src/main/java/com/smartbear/ready/jenkins/JenkinsSoapUIProTestRunner.java
+++ b/src/main/java/com/smartbear/ready/jenkins/JenkinsSoapUIProTestRunner.java
@@ -38,6 +38,7 @@ public class JenkinsSoapUIProTestRunner extends Builder implements SimpleBuildSt
     private String testCaseTags;
     private Secret projectPassword;
     private String environment;
+    private String slmLicenceAccessKey;
 
     @DataBoundConstructor
     public JenkinsSoapUIProTestRunner(String pathToTestrunner,
@@ -108,6 +109,15 @@ public class JenkinsSoapUIProTestRunner extends Builder implements SimpleBuildSt
         this.environment = environment;
     }
 
+    public String getSlmLicenceAccessKey() {
+        return slmLicenceAccessKey;
+    }
+
+    @DataBoundSetter
+    public void setSlmLicenceAccessKey(String slmLicenceAccessKey) {
+        this.slmLicenceAccessKey = slmLicenceAccessKey;
+    }
+
     @Override
     public void perform(@Nonnull Run<?, ?> run, @Nonnull FilePath workspace, @Nonnull Launcher launcher, @Nonnull TaskListener listener) throws InterruptedException, IOException {
         Proc process = null;
@@ -123,6 +133,7 @@ public class JenkinsSoapUIProTestRunner extends Builder implements SimpleBuildSt
                     .withTestCaseTags(testCaseTags)
                     .withProjectPassword(Secret.toString(getProjectPassword()))
                     .withEnvironment(environment)
+                    .withSlmLicenceAccessKey(slmLicenceAccessKey)
                     .withWorkspace(workspace)
                     .build(), run, launcher, listener);
             if (process == null) {

--- a/src/main/java/com/smartbear/ready/jenkins/ParameterContainer.java
+++ b/src/main/java/com/smartbear/ready/jenkins/ParameterContainer.java
@@ -11,6 +11,7 @@ public class ParameterContainer {
     private String testCaseTags;
     private String projectPassword;
     private String environment;
+    private String slmLicenceAccessKey;
     private FilePath workspace;
 
     public String getPathToTestrunner() {
@@ -43,6 +44,10 @@ public class ParameterContainer {
 
     public String getEnvironment() {
         return environment;
+    }
+
+    public String getSlmLicenceAccessKey() {
+        return slmLicenceAccessKey;
     }
 
     public FilePath getWorkspace() {
@@ -101,5 +106,9 @@ public class ParameterContainer {
             return this;
         }
 
+        public Builder withSlmLicenceAccessKey(String slmLicenceAccessKey) {
+            parameterContainer.slmLicenceAccessKey = slmLicenceAccessKey;
+            return this;
+        }
     }
 }

--- a/src/main/java/com/smartbear/ready/jenkins/ProcessRunner.java
+++ b/src/main/java/com/smartbear/ready/jenkins/ProcessRunner.java
@@ -119,10 +119,14 @@ class ProcessRunner {
         if (StringUtils.isNotBlank(params.getEnvironment())) {
             processParameterList.addAll(Arrays.asList("-E", params.getEnvironment()));
         }
+        if (StringUtils.isNotBlank(params.getSlmLicenceAccessKey())) {
+            processParameterList.addAll(Arrays.asList("-K", params.getSlmLicenceAccessKey()));
+        }
 
         String projectFilePath = envVars.expand(params.getPathToProjectFile());
         FilePath projectFile = new FilePath(channel, projectFilePath);
-        if (StringUtils.isNotBlank(projectFilePath) && projectFile.exists() && (projectFile.isDirectory() || projectFile.length() != 0)) {
+        if (StringUtils.isNotBlank(projectFilePath) && projectFile.exists()
+                && (projectFile.isDirectory() || projectFile.length() != 0)) {
             try {
                 isSoapUIProProject = ProjectFileValidator.isValidProjectPath(projectFile);
             } catch (Exception e) {

--- a/src/main/resources/com/smartbear/ready/jenkins/JenkinsSoapUIProTestRunner/config.jelly
+++ b/src/main/resources/com/smartbear/ready/jenkins/JenkinsSoapUIProTestRunner/config.jelly
@@ -34,5 +34,9 @@
              description="Specifies the environment configuration for the test run.">
         <f:textbox/>
     </f:entry>
+    <f:entry title="SLM Licence Access Key" field="slmLicenceAccessKey"
+             description="Specifies SLM Licence Access Key (Optional)">
+        <f:textbox/>
+    </f:entry>
 
 </j:jelly>


### PR DESCRIPTION
This Pull Request allow SoapUI Pro Functional Testing Plugin to pass additional parameter to testrunner application, which specifies SLM Licence Access Key.
Jira ticket: https://smartbear.atlassian.net/browse/RIA-20223

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira

