### PR TITLE
Ria 21085 user password should work with saas

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ You can find more information on how to use the plugin in [ReadyAPI documentatio
 
 ### Version history
 
+#### Version 1.10 (August 04, 2023)
+
+* *Fixed*: SLM License API Host and Port are no longer mandatory for Username and Password authorisation method allowing getting license from SLM SaaS.
+
 #### Version 1.9 (June 14, 2023)
 
 * *New feature*: Added the possibility to select license authorisation method (File Based, Access Key, Username and Password, Access for everyone) and pass proper parameters for each method.

--- a/pom.xml
+++ b/pom.xml
@@ -5,12 +5,11 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.33</version>
-        <relativePath />
+        <version>2.15</version>
     </parent>
 
     <properties>
-        <jenkins.version>1.625</jenkins.version>
+        <jenkins.version>1.625.3</jenkins.version>
         <java.level>7</java.level>
         <findbugs.failOnError>false</findbugs.failOnError>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -5,11 +5,12 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.15</version>
+        <version>2.33</version>
+        <relativePath />
     </parent>
 
     <properties>
-        <jenkins.version>1.625.3</jenkins.version>
+        <jenkins.version>1.625</jenkins.version>
         <java.level>7</java.level>
         <findbugs.failOnError>false</findbugs.failOnError>
     </properties>

--- a/src/main/java/com/smartbear/ready/jenkins/JenkinsSoapUIProTestRunner.java
+++ b/src/main/java/com/smartbear/ready/jenkins/JenkinsSoapUIProTestRunner.java
@@ -304,9 +304,14 @@ public class JenkinsSoapUIProTestRunner extends Builder implements SimpleBuildSt
 
         public FormValidation doCheckSlmLicenceApiPort(@QueryParameter String value, @QueryParameter String authMethod) {
             final AuthMethod slmAuthMethod = AuthMethod.valueOf(authMethod);
-            if (!isValidPort(value) && slmAuthMethod == AuthMethod.ACCESS_FOR_EVERYONE) {
-                return FormValidation
-                        .error("Please, enter valid SLM Licence API Port for " + ACCESS_FOR_EVERYONE + " authentication method");
+            if (!isValidPort(value)) {
+                if (slmAuthMethod == AuthMethod.ACCESS_FOR_EVERYONE) {
+                    return FormValidation
+                            .error("Please, enter valid SLM Licence API Port for " + ACCESS_FOR_EVERYONE + " authentication method");
+                } else if (StringUtils.isNotEmpty(value)) {
+                    return FormValidation
+                            .error("Please, enter valid SLM Licence API Port");
+                }
             }
             return FormValidation.ok();
         }

--- a/src/main/java/com/smartbear/ready/jenkins/JenkinsSoapUIProTestRunner.java
+++ b/src/main/java/com/smartbear/ready/jenkins/JenkinsSoapUIProTestRunner.java
@@ -38,7 +38,8 @@ public class JenkinsSoapUIProTestRunner extends Builder implements SimpleBuildSt
     private static final String USER_AND_PASSWORD = "User And Password";
     private static final String USERNAME = "Username";
     private static final String PASSWORD = "Password";
-
+    private static final String SLM_LICENCE_API_HOST = "SLM Licence API Host";
+    private static final String ACCESS_FOR_EVERYONE = "Access for Everyone";
     private final String pathToTestrunner;
     private final String pathToProjectFile;
     private String testSuite;
@@ -297,27 +298,15 @@ public class JenkinsSoapUIProTestRunner extends Builder implements SimpleBuildSt
         }
 
         public FormValidation doCheckSlmLicenceApiHost(@QueryParameter String value, @QueryParameter String authMethod) {
-            final AuthMethod slmAuthMethod = AuthMethod.valueOf(authMethod);
-            if (StringUtils.isEmpty(value)) {
-                switch (slmAuthMethod) {
-                    case USER_AND_PASSWORD:
-                        return FormValidation.error("Please, enter valid SLM Licence API Host for User And Password authentication method");
-                    case ACCESS_FOR_EVERYONE:
-                        return FormValidation.error("Please, enter valid SLM Licence API Host for Access for Everyone authentication method");
-                }
-            }
-            return FormValidation.ok();
+            return validateEmptyValue(value, AuthMethod.ACCESS_FOR_EVERYONE, authMethod,
+                    SLM_LICENCE_API_HOST, ACCESS_FOR_EVERYONE);
         }
 
         public FormValidation doCheckSlmLicenceApiPort(@QueryParameter String value, @QueryParameter String authMethod) {
             final AuthMethod slmAuthMethod = AuthMethod.valueOf(authMethod);
-            if (!isValidPort(value)) {
-                switch (slmAuthMethod) {
-                    case USER_AND_PASSWORD:
-                        return FormValidation.error("Please, enter valid SLM Licence API Port for User And Password authentication method");
-                    case ACCESS_FOR_EVERYONE:
-                        return FormValidation.error("Please, enter valid SLM Licence API Port for Access for Everyone authentication method");
-                }
+            if (!isValidPort(value) && slmAuthMethod == AuthMethod.ACCESS_FOR_EVERYONE) {
+                return FormValidation
+                        .error("Please, enter valid SLM Licence API Port for " + ACCESS_FOR_EVERYONE + " authentication method");
             }
             return FormValidation.ok();
         }

--- a/src/test/java/com/smartbear/ready/jenkins/JenkinsSoapUIProTestRunnerTest.java
+++ b/src/test/java/com/smartbear/ready/jenkins/JenkinsSoapUIProTestRunnerTest.java
@@ -18,18 +18,6 @@ public class JenkinsSoapUIProTestRunnerTest {
     }
 
     @Test
-    public void validateEmptySlmLicenceApiHostForUserAndPasswordMethodTest() {
-        // given
-        final String authMethod = "USER_AND_PASSWORD";
-
-        // when
-        final FormValidation result = validationService.doCheckSlmLicenceApiHost("", authMethod);
-
-        // then
-        assertThat(result.kind, is(Kind.ERROR));
-    }
-
-    @Test
     public void validateEmptySlmLicenceApiHostForAccessForEveryoneMethodTest() {
         // given
         final String authMethod = "ACCESS_FOR_EVERYONE";
@@ -51,18 +39,6 @@ public class JenkinsSoapUIProTestRunnerTest {
 
         // then
         assertThat(result.kind, is(Kind.OK));
-    }
-
-    @Test
-    public void validateEmptySlmLicenceApiPortForUserAndPasswordMethodTest() {
-        // given
-        final String authMethod = "USER_AND_PASSWORD";
-
-        // when
-        final FormValidation result = validationService.doCheckSlmLicenceApiPort("", authMethod);
-
-        // then
-        assertThat(result.kind, is(Kind.ERROR));
     }
 
     @Test
@@ -90,9 +66,9 @@ public class JenkinsSoapUIProTestRunnerTest {
     }
 
     @Test
-    public void validateStringSlmLicenceApiPortForUserAndPasswordMethodTest() {
+    public void validateStringSlmLicenceApiPortForAccessForEveryoneMethodTest() {
         // given
-        final String authMethod = "USER_AND_PASSWORD";
+        final String authMethod = "ACCESS_FOR_EVERYONE";
         final String port = "abc";
 
         // when
@@ -103,9 +79,9 @@ public class JenkinsSoapUIProTestRunnerTest {
     }
 
     @Test
-    public void validateTooLargeSlmLicenceApiPortForUserAndPasswordMethodTest() {
+    public void validateTooLargeSlmLicenceApiPortForAccessForEveryoneMethodTest() {
         // given
-        final String authMethod = "USER_AND_PASSWORD";
+        final String authMethod = "ACCESS_FOR_EVERYONE";
         final String port = "88888";
 
         // when
@@ -116,9 +92,9 @@ public class JenkinsSoapUIProTestRunnerTest {
     }
 
     @Test
-    public void validateNegativeSlmLicenceApiPortForUserAndPasswordMethodTest() {
+    public void validateNegativeSlmLicenceApiPortForAccessForEveryoneMethodTest() {
         // given
-        final String authMethod = "USER_AND_PASSWORD";
+        final String authMethod = "ACCESS_FOR_EVERYONE";
         final String port = "-12";
 
         // when


### PR DESCRIPTION
RIA-21085: host and port are no longer mandatory for User and Password authorisation method

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
