### PR TITLE
RIA-22484 added client credentials option to install license for on-prem-slm

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ The build step has the following settings:
 * **SLM License API Host** - Specifies SLM License API Host.
 * **SLM License API Port** - Specifies SLM License API Port.
 * **SLM License Access Key** - Specifies SLM License Access Key.
+* **SLM License Client Id** - Specifies SLM License Client Id.
+* **SLM License Client Secret** - Specifies SLM License Client Secret.
 * **Username** - Specifies username.
 * **Password** - Specifies password.
 

--- a/src/main/java/com/smartbear/ready/jenkins/AuthMethod.java
+++ b/src/main/java/com/smartbear/ready/jenkins/AuthMethod.java
@@ -2,6 +2,6 @@ package com.smartbear.ready.jenkins;
 
 public enum AuthMethod {
 
-    FILE_BASED, API_KEY, USER_AND_PASSWORD, ACCESS_FOR_EVERYONE
+    FILE_BASED, API_KEY, USER_AND_PASSWORD, ACCESS_FOR_EVERYONE, CLIENT_CREDENTIALS
 
 }

--- a/src/main/java/com/smartbear/ready/jenkins/JenkinsSoapUIProTestRunner.java
+++ b/src/main/java/com/smartbear/ready/jenkins/JenkinsSoapUIProTestRunner.java
@@ -39,6 +39,9 @@ public class JenkinsSoapUIProTestRunner extends Builder implements SimpleBuildSt
     private static final String USER_AND_PASSWORD = "User And Password";
     private static final String USERNAME = "Username";
     private static final String PASSWORD = "Password";
+    private static final String CLIENT_ID = "SLM License Client Id";
+    private static final String CLIENT_SECRET = "SLM License Client Secret";
+    private static final String CLIENT_CREDENTIALS = "Client Credentials";
     private final String pathToTestrunner;
     private final String pathToProjectFile;
     private String testSuite;
@@ -53,6 +56,8 @@ public class JenkinsSoapUIProTestRunner extends Builder implements SimpleBuildSt
     private String slmLicenceAccessKey;
     private String user;
     private String password;
+    private String slmLicenseClientId;
+    private String slmLicenseClientSecret;
 
     @DataBoundConstructor
     public JenkinsSoapUIProTestRunner(String pathToTestrunner,
@@ -177,6 +182,24 @@ public class JenkinsSoapUIProTestRunner extends Builder implements SimpleBuildSt
         this.password = password;
     }
 
+    public String getSlmLicenseClientId() {
+        return this.slmLicenseClientId;
+    }
+
+    @DataBoundSetter
+    public void setSlmLicenseClientId(String slmLicenseClientId) {
+        this.slmLicenseClientId = slmLicenseClientId;
+    }
+
+    public String getSlmLicenseClientSecret() {
+        return this.slmLicenseClientSecret;
+    }
+
+    @DataBoundSetter
+    public void setSlmLicenseClientSecret(String slmLicenseClientSecret) {
+        this.slmLicenseClientSecret = slmLicenseClientSecret;
+    }
+
     @Override
     public void perform(@Nonnull Run<?, ?> run, @Nonnull FilePath workspace, @Nonnull Launcher launcher, @Nonnull TaskListener listener) throws InterruptedException, IOException {
         Proc process = null;
@@ -199,6 +222,8 @@ public class JenkinsSoapUIProTestRunner extends Builder implements SimpleBuildSt
                     .withUser(user)
                     .withPassword(password)
                     .withWorkspace(workspace)
+                    .withSlmLicenseClientId(slmLicenseClientId)
+                    .withSlmLicenseClientSecret(slmLicenseClientSecret)
                     .build(), run, launcher, listener);
             if (process == null) {
                 throw new AbortException("Could not start ReadyAPI functional testing.");
@@ -282,6 +307,7 @@ public class JenkinsSoapUIProTestRunner extends Builder implements SimpleBuildSt
             items.add("API KEY", "API_KEY");
             items.add("User and Password", "USER_AND_PASSWORD");
             items.add("Access for everyone", "ACCESS_FOR_EVERYONE");
+            items.add("Client Credentials", "CLIENT_CREDENTIALS");
 
             return items;
         }
@@ -323,6 +349,8 @@ public class JenkinsSoapUIProTestRunner extends Builder implements SimpleBuildSt
                         return FormValidation.error("Please, enter valid SLM Licence API Host for User And Password authentication method");
                     case ACCESS_FOR_EVERYONE:
                         return FormValidation.error("Please, enter valid SLM Licence API Host for Access for Everyone authentication method");
+                    case CLIENT_CREDENTIALS:
+                        return FormValidation.error("Please, enter valid SLM Licence API Host for Client Credentials authentication method");
                 }
             }
             return FormValidation.ok();
@@ -336,6 +364,8 @@ public class JenkinsSoapUIProTestRunner extends Builder implements SimpleBuildSt
                         return FormValidation.error("Please, enter valid SLM Licence API Port for User And Password authentication method");
                     case ACCESS_FOR_EVERYONE:
                         return FormValidation.error("Please, enter valid SLM Licence API Port for Access for Everyone authentication method");
+                    case CLIENT_CREDENTIALS:
+                        return FormValidation.error("Please, enter valid SLM Licence API Port for Client Credentials authentication method");
                 }
             }
             return FormValidation.ok();
@@ -367,6 +397,16 @@ public class JenkinsSoapUIProTestRunner extends Builder implements SimpleBuildSt
         public FormValidation doCheckPassword(@QueryParameter String value, @QueryParameter String authMethod) {
             return validateEmptyValue(value, AuthMethod.USER_AND_PASSWORD, authMethod,
                     PASSWORD, USER_AND_PASSWORD);
+        }
+
+        public FormValidation doCheckSlmLicenseClientId(@QueryParameter String value, @QueryParameter String authMethod) {
+            return validateEmptyValue(value, AuthMethod.CLIENT_CREDENTIALS, authMethod,
+                    CLIENT_ID, CLIENT_CREDENTIALS);
+        }
+
+        public FormValidation doCheckSlmLicenseClientSecret(@QueryParameter String value, @QueryParameter String authMethod) {
+            return validateEmptyValue(value, AuthMethod.CLIENT_CREDENTIALS, authMethod,
+                    CLIENT_SECRET, CLIENT_CREDENTIALS);
         }
 
         private FormValidation validateEmptyValue(final String value, final AuthMethod authMethod,

--- a/src/main/java/com/smartbear/ready/jenkins/ParameterContainer.java
+++ b/src/main/java/com/smartbear/ready/jenkins/ParameterContainer.java
@@ -18,6 +18,9 @@ public class ParameterContainer {
     private String user;
     private String password;
     private FilePath workspace;
+    private String slmLicenseClientId;
+    private String slmLicenseClientSecret;
+
 
     public String getPathToTestrunner() {
         return pathToTestrunner;
@@ -77,6 +80,14 @@ public class ParameterContainer {
 
     public String getPassword() {
         return password;
+    }
+
+    public String getSlmLicenseClientId() {
+        return this.slmLicenseClientId;
+    }
+
+    public String getSlmLicenseClientSecret() {
+        return this.slmLicenseClientSecret;
     }
 
     public static class Builder {
@@ -158,6 +169,16 @@ public class ParameterContainer {
 
         public Builder withPassword(String password) {
             parameterContainer.password = password;
+            return this;
+        }
+
+        public Builder withSlmLicenseClientId(String slmLicenseClientId) {
+            parameterContainer.slmLicenseClientId = slmLicenseClientId;
+            return this;
+        }
+
+        public Builder withSlmLicenseClientSecret(String slmLicenseClientSecret) {
+            parameterContainer.slmLicenseClientSecret = slmLicenseClientSecret;
             return this;
         }
     }

--- a/src/main/java/com/smartbear/ready/jenkins/ProcessRunner.java
+++ b/src/main/java/com/smartbear/ready/jenkins/ProcessRunner.java
@@ -215,6 +215,10 @@ class ProcessRunner {
             case ACCESS_FOR_EVERYONE:
                 processParameterList.add("-DlicenseApiAccessForEveryone=true");
                 break;
+            case CLIENT_CREDENTIALS:
+                addParameterIfNotBlank(processParameterList, "-ci", params.getSlmLicenseClientId());
+                addParameterIfNotBlank(processParameterList, "-cs", params.getSlmLicenseClientSecret());
+                break;
             default:
                 break;
         }

--- a/src/main/resources/com/smartbear/ready/jenkins/JenkinsSoapUIProTestRunner/config.jelly
+++ b/src/main/resources/com/smartbear/ready/jenkins/JenkinsSoapUIProTestRunner/config.jelly
@@ -52,4 +52,10 @@
     <f:entry title="Password" field="password" description="Password">
         <f:password/>
     </f:entry>
+    <f:entry title="SLM License Client Id" field="slmLicenseClientId" description="Specifies SLM License Client Id">
+        <f:textbox/>
+    </f:entry>
+    <f:entry title="SLM License Client Secret" field="slmLicenseClientSecret" description="Specifies SLM License Client Secret">
+        <f:textbox/>
+    </f:entry>
 </j:jelly>

--- a/src/test/java/com/smartbear/ready/jenkins/JenkinsSoapUIProTestRunnerTest.java
+++ b/src/test/java/com/smartbear/ready/jenkins/JenkinsSoapUIProTestRunnerTest.java
@@ -11,6 +11,7 @@ import static org.junit.Assert.*;
 public class JenkinsSoapUIProTestRunnerTest {
 
     private static JenkinsSoapUIProTestRunner.DescriptorImpl validationService;
+    private static final String CLIENT_CREDENTIALS_AUTH_METHOD = AuthMethod.CLIENT_CREDENTIALS.name();
 
     @BeforeClass
     public static void setUp() {
@@ -202,4 +203,77 @@ public class JenkinsSoapUIProTestRunnerTest {
         // then
         assertThat(result.kind, is(Kind.ERROR));
     }
+
+    @Test
+    public void validateEmptyClientIdForClientCredentialsMethodTest() {
+        // when
+        final FormValidation result = validationService.doCheckSlmLicenseClientId("", CLIENT_CREDENTIALS_AUTH_METHOD);
+
+        // then
+        assertThat(result.kind, is(Kind.ERROR));
+    }
+
+    @Test
+    public void validateEmptyClientSecretForClientCredentialsMethodTest() {
+        // when
+        final FormValidation result = validationService.doCheckSlmLicenseClientSecret("", CLIENT_CREDENTIALS_AUTH_METHOD);
+
+        // then
+        assertThat(result.kind, is(Kind.ERROR));
+    }
+
+    @Test
+    public void validateEmptySlmLicenceApiHostForClientCredentialsMethodTest() {
+        // when
+        final FormValidation result = validationService.doCheckSlmLicenceApiHost("", CLIENT_CREDENTIALS_AUTH_METHOD);
+
+        // then
+        assertThat(result.kind, is(Kind.ERROR));
+    }
+
+    @Test
+    public void validateEmptySlmLicenceApiPortForClientCredentialsMethodTest() {
+        // when
+        final FormValidation result = validationService.doCheckSlmLicenceApiPort("", CLIENT_CREDENTIALS_AUTH_METHOD);
+
+        // then
+        assertThat(result.kind, is(Kind.ERROR));
+    }
+
+    @Test
+    public void validateStringSlmLicenceApiPortForClientCredentialsMethodTest() {
+        // when
+        final FormValidation result = validationService.doCheckSlmLicenceApiPort("abc", CLIENT_CREDENTIALS_AUTH_METHOD);
+
+        // then
+        assertThat(result.kind, is(Kind.ERROR));
+    }
+
+    @Test
+    public void validateTooLargeSlmLicenceApiPortForClientCredentialsMethodTest() {
+        // when
+        final FormValidation result = validationService.doCheckSlmLicenceApiPort("65536", CLIENT_CREDENTIALS_AUTH_METHOD);
+
+        // then
+        assertThat(result.kind, is(Kind.ERROR));
+    }
+
+    @Test
+    public void validateNegativeSlmLicenceApiPortForClientCredentialsMethodTest() {
+        // when
+        final FormValidation result = validationService.doCheckSlmLicenceApiPort("-8080", CLIENT_CREDENTIALS_AUTH_METHOD);
+
+        // then
+        assertThat(result.kind, is(Kind.ERROR));
+    }
+
+    @Test
+    public void validateProperSlmLicenceApiPortForClientCredentialsMethodTest() {
+        // when
+        final FormValidation result = validationService.doCheckSlmLicenceApiPort("8080", CLIENT_CREDENTIALS_AUTH_METHOD);
+
+        // then
+        assertThat(result.kind, is(Kind.OK));
+    }
+
 }

--- a/src/test/java/com/smartbear/ready/jenkins/ProcessRunnerTest.java
+++ b/src/test/java/com/smartbear/ready/jenkins/ProcessRunnerTest.java
@@ -157,4 +157,46 @@ public class ProcessRunnerTest {
         assertThat(processParameterList.size(), is(1));
         assertThat(processParameterList, hasItems("-DlicenseApiAccessForEveryone=true"));
     }
+
+    @Test
+    public void addAuthorisationRelatedParametersForClientCredentialsAuthMethodTest()
+            throws InvocationTargetException, IllegalAccessException {
+        // given
+        List<String> processParameterList = new ArrayList<>();
+        ParameterContainer params = new ParameterContainer.Builder()
+                .withAuthMethod(AuthMethod.CLIENT_CREDENTIALS.name())
+                .withSlmLicenceApiHost("localhost")
+                .withSlmLicenceApiPort("1234")
+                .withSlmLicenseClientId("testId")
+                .withSlmLicenseClientSecret("testSecret")
+                .build();
+
+        // when
+        testedMethod.invoke(processRunner, processParameterList, params);
+
+        // then
+        assertThat(processParameterList.size(), is(6));
+        assertThat(processParameterList,
+                hasItems("-DlicenseApiHost=localhost", "-DlicenseApiPort=1234", "-ci", "testId", "-cs", "testSecret"));
+    }
+
+    @Test
+    public void addAuthorisationRelatedParametersWithoutHostAndPortForClientCredentialsAuthMethodTest()
+            throws InvocationTargetException, IllegalAccessException {
+        // given
+        List<String> processParameterList = new ArrayList<>();
+        ParameterContainer params = new ParameterContainer.Builder()
+                .withAuthMethod(AuthMethod.CLIENT_CREDENTIALS.name())
+                .withSlmLicenseClientId("testId")
+                .withSlmLicenseClientSecret("testSecret")
+                .build();
+
+        // when
+        testedMethod.invoke(processRunner, processParameterList, params);
+
+        // then
+        assertThat(processParameterList.size(), is(4));
+        assertThat(processParameterList,
+                hasItems("-ci", "testId", "-cs", "testSecret"));
+    }
 }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
This PR contains changes for allowing users to use SLM On-prem Client credentials to use the license for running the testrunner.
https://smartbear.atlassian.net/browse/RIA-22484

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
